### PR TITLE
feat: new commands, JSON output, NO_COLOR, and update checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -81,6 +87,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -181,6 +193,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,7 +217,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -205,12 +227,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
  "console",
+ "fuzzy-matcher",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -246,7 +278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -260,6 +292,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -280,6 +322,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -330,14 +392,17 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "clap_mangen",
  "dialoguer",
  "git2",
  "owo-colors",
  "regex",
  "serde",
+ "serde_json",
  "tabled",
  "thiserror",
  "toml",
+ "ureq",
 ]
 
 [[package]]
@@ -360,6 +425,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -506,6 +577,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +702,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +755,10 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
+]
 
 [[package]]
 name = "papergrid"
@@ -782,6 +884,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roff"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf2048e0e979efb2ca7b91c4f1a8d77c91853e9b987c94c555668a8994915ad"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,7 +913,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -871,6 +1028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +1050,31 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
 
 [[package]]
 name = "syn"
@@ -944,7 +1132,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -974,6 +1162,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1046,6 +1243,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1295,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1173,6 +1400,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,12 +1478,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,11 @@ toml = "0.8"
 git2 = "0.20"
 anyhow = "1.0"
 thiserror = "2.0"
-owo-colors = "4.3"
+owo-colors = { version = "4.3", features = ["supports-colors"] }
 tabled = "0.20"
-dialoguer = "0.12"
+dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 chrono = { version = "0.4" }
 regex = "1"
+ureq = { version = "2", features = ["json"] }
+clap_mangen = "0.2"
+serde_json = "1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,16 @@
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
+use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "gitpilot", about = "A Git assistant for daily developer workflow", version)]
 pub struct Cli {
+    #[arg(long, global = true, help = "Output results as JSON")]
+    pub json: bool,
+
+    #[arg(long, global = true, env = "NO_COLOR", help = "Disable color output")]
+    pub no_color: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -25,10 +32,74 @@ pub enum Commands {
         /// Base branch to check merges against
         #[arg(long, short)]
         base: Option<String>,
+        /// Preview branches to delete without actually deleting
+        #[arg(long)]
+        dry_run: bool,
     },
-    /// Generate shell completion scripts
+    /// Interactive branch switcher
+    Switch {
+        /// Include remote branches
+        #[arg(long)]
+        remote: bool,
+    },
+    /// Fetch and sync current branch with base
+    Sync {
+        /// Base branch to sync against
+        #[arg(long, short)]
+        base: Option<String>,
+    },
+    /// Browse commit history with filters
+    Log {
+        /// Filter by author name
+        #[arg(long)]
+        author: Option<String>,
+        /// Filter since date (YYYY-MM-DD, Nd, Nw, Nm)
+        #[arg(long)]
+        since: Option<String>,
+        /// Filter by commit message pattern
+        #[arg(long)]
+        grep: Option<String>,
+        /// Number of commits to show
+        #[arg(long, short, default_value = "30")]
+        count: usize,
+    },
+    /// Interactive commit undo (reset HEAD)
+    Undo {
+        /// Number of recent commits to show for selection
+        #[arg(long, short, default_value = "5")]
+        count: usize,
+    },
+    /// Interactive stash manager
+    Stash,
+    /// Initialize a .gitpilot.toml config file
+    Init {
+        /// Also install a pre-commit hook
+        #[arg(long)]
+        hook: bool,
+    },
+    /// Generate shell completions or man page
+    Generate {
+        #[command(subcommand)]
+        target: GenerateTarget,
+    },
+    /// Generate shell completion scripts (shorthand)
     Completions {
         #[arg(value_enum)]
         shell: Shell,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum GenerateTarget {
+    /// Generate shell completion script
+    Completions {
+        #[arg(value_enum)]
+        shell: Shell,
+    },
+    /// Generate man page
+    Man {
+        /// Output file path (defaults to stdout)
+        #[arg(long, short)]
+        output: Option<PathBuf>,
     },
 }

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -1,10 +1,18 @@
 use anyhow::Result;
 use dialoguer::{MultiSelect, Confirm, theme::ColorfulTheme};
+use serde::Serialize;
 use crate::commands::CommandContext;
 use crate::display::{tables, theme};
 use crate::git::branches::{list_branches, BranchState};
 
-pub fn run(ctx: &CommandContext, base: Option<&str>) -> Result<()> {
+#[derive(Serialize)]
+struct CleanupJson {
+    dry_run: bool,
+    deleted: Vec<String>,
+    would_delete: Vec<String>,
+}
+
+pub fn run(ctx: &CommandContext, base: Option<&str>, dry_run: bool) -> Result<()> {
     let base_branch = base
         .unwrap_or(&ctx.config.base_branch)
         .to_string();
@@ -28,13 +36,32 @@ pub fn run(ctx: &CommandContext, base: Option<&str>) -> Result<()> {
         .collect();
 
     if candidates.is_empty() {
-        println!("{}", theme::success("No branches to clean up."));
+        if ctx.json {
+            println!("{}", serde_json::to_string(&CleanupJson { dry_run, deleted: vec![], would_delete: vec![] })?);
+        } else {
+            println!("{}", theme::success("No branches to clean up."));
+        }
         return Ok(());
     }
 
-    println!("{}", theme::heading("Branches eligible for cleanup:"));
-    println!("{}", tables::branch_table(&candidates));
-    println!();
+    if !ctx.json {
+        println!("{}", theme::heading("Branches eligible for cleanup:"));
+        println!("{}", tables::branch_table(&candidates));
+        println!();
+    }
+
+    if dry_run {
+        let names: Vec<String> = candidates.iter().map(|b| b.name.clone()).collect();
+        if ctx.json {
+            println!("{}", serde_json::to_string(&CleanupJson { dry_run: true, deleted: vec![], would_delete: names })?);
+        } else {
+            println!("{}", theme::dim("Dry run — would delete:"));
+            for name in &names {
+                println!("  {}", name);
+            }
+        }
+        return Ok(());
+    }
 
     let labels: Vec<String> = candidates
         .iter()
@@ -47,7 +74,11 @@ pub fn run(ctx: &CommandContext, base: Option<&str>) -> Result<()> {
         .interact()?;
 
     if selections.is_empty() {
-        println!("{}", theme::dim("No branches selected."));
+        if ctx.json {
+            println!("{}", serde_json::to_string(&CleanupJson { dry_run: false, deleted: vec![], would_delete: vec![] })?);
+        } else {
+            println!("{}", theme::dim("No branches selected."));
+        }
         return Ok(());
     }
 
@@ -64,18 +95,40 @@ pub fn run(ctx: &CommandContext, base: Option<&str>) -> Result<()> {
         .interact()?;
 
     if !confirmed {
-        println!("{}", theme::dim("Aborted."));
+        if ctx.json {
+            println!("{}", serde_json::to_string(&CleanupJson { dry_run: false, deleted: vec![], would_delete: vec![] })?);
+        } else {
+            println!("{}", theme::dim("Aborted."));
+        }
         return Ok(());
     }
 
+    let mut deleted = Vec::new();
     for name in selected_names {
         match repo.find_branch(name, git2::BranchType::Local) {
             Ok(mut branch) => match branch.delete() {
-                Ok(_) => println!("{} {}", theme::success("Deleted:"), name),
-                Err(e) => println!("{} {}: {}", theme::error("Failed:"), name, e),
+                Ok(_) => {
+                    if !ctx.json {
+                        println!("{} {}", theme::success("Deleted:"), name);
+                    }
+                    deleted.push(name.to_string());
+                }
+                Err(e) => {
+                    if !ctx.json {
+                        println!("{} {}: {}", theme::error("Failed:"), name, e);
+                    }
+                }
             },
-            Err(e) => println!("{} {}: {}", theme::error("Failed:"), name, e),
+            Err(e) => {
+                if !ctx.json {
+                    println!("{} {}: {}", theme::error("Failed:"), name, e);
+                }
+            }
         }
+    }
+
+    if ctx.json {
+        println!("{}", serde_json::to_string(&CleanupJson { dry_run: false, deleted, would_delete: vec![] })?);
     }
 
     Ok(())

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use clap::CommandFactory;
+use clap_mangen::Man;
+use crate::cli::{Cli, GenerateTarget};
+use crate::commands::completions;
+
+pub fn run(target: &GenerateTarget) -> Result<()> {
+    match target {
+        GenerateTarget::Completions { shell } => {
+            completions::run(*shell)
+        }
+        GenerateTarget::Man { output } => {
+            let cmd = Cli::command();
+            let man = Man::new(cmd);
+            match output {
+                Some(path) => {
+                    let file = File::create(path)?;
+                    let mut writer = BufWriter::new(file);
+                    man.render(&mut writer)?;
+                    writer.flush()?;
+                    eprintln!("Man page written to {}", path.display());
+                }
+                None => {
+                    let stdout = io::stdout();
+                    let mut writer = BufWriter::new(stdout.lock());
+                    man.render(&mut writer)?;
+                    writer.flush()?;
+                }
+            }
+            Ok(())
+        }
+    }
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,89 @@
+use anyhow::{anyhow, Result};
+use dialoguer::{Confirm, theme::ColorfulTheme};
+use crate::config::Config;
+use crate::display::theme;
+
+const TOML_TEMPLATE: &str = r#"# gitpilot configuration
+# See https://github.com/harshsandhu44/gitpilot for documentation
+
+# Base branch for comparisons (summary, cleanup, sync)
+# base_branch = "main"
+
+# Branches that will never be deleted by cleanup
+# protected_branches = ["main", "master", "develop"]
+
+# Branches older than this (in days) are considered stale
+# stale_days = 30
+
+# Regex patterns to flag as potential secrets in review
+# review_secrets_patterns = [
+#   "AWS_SECRET",
+#   "api_key\\s*=",
+#   "-----BEGIN",
+#   "ghp_[A-Za-z0-9]+",
+#   "password\\s*=",
+# ]
+
+# Sync strategy: "rebase" or "merge"
+# sync_strategy = "rebase"
+"#;
+
+pub fn run(_config: &Config, install_hook: bool) -> Result<()> {
+    let path = std::env::current_dir()?.join(".gitpilot.toml");
+
+    if path.exists() {
+        let overwrite = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(".gitpilot.toml already exists. Overwrite?")
+            .default(false)
+            .interact()?;
+        if !overwrite {
+            println!("{}", theme::dim("Aborted."));
+            return Ok(());
+        }
+    }
+
+    std::fs::write(&path, TOML_TEMPLATE)?;
+    println!("{} .gitpilot.toml", theme::success("Created"));
+
+    if install_hook {
+        install_pre_commit_hook()?;
+    }
+
+    Ok(())
+}
+
+fn install_pre_commit_hook() -> Result<()> {
+    let hook_dir = std::env::current_dir()?.join(".git").join("hooks");
+    if !hook_dir.exists() {
+        return Err(anyhow!("No .git/hooks directory found. Are you in a git repository?"));
+    }
+
+    let hook_path = hook_dir.join("pre-commit");
+    let hook_line = "gitpilot review\n";
+
+    if hook_path.exists() {
+        let existing = std::fs::read_to_string(&hook_path)?;
+        if existing.contains("gitpilot review") {
+            println!("{}", theme::dim("pre-commit hook already contains gitpilot review — skipping."));
+            return Ok(());
+        }
+        let mut content = existing;
+        if !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push_str(hook_line);
+        std::fs::write(&hook_path, content)?;
+    } else {
+        std::fs::write(&hook_path, format!("#!/bin/sh\n{}", hook_line))?;
+    }
+
+    // Set executable permissions
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&hook_path, std::fs::Permissions::from_mode(0o755))?;
+    }
+
+    println!("{} .git/hooks/pre-commit", theme::success("Installed hook"));
+    Ok(())
+}

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -1,0 +1,109 @@
+use anyhow::Result;
+use chrono::{DateTime, Duration, NaiveDate, Utc};
+use serde::Serialize;
+use std::collections::HashMap;
+use crate::commands::CommandContext;
+use crate::display::theme;
+use crate::git::commits::{filtered, LogFilter};
+
+#[derive(Serialize)]
+struct CommitJson {
+    hash: String,
+    author: String,
+    date: String,
+    message: String,
+    refs: Vec<String>,
+}
+
+pub fn run(
+    ctx: &CommandContext,
+    author: Option<&str>,
+    since: Option<&str>,
+    grep: Option<&str>,
+    count: usize,
+) -> Result<()> {
+    let since_dt = since.map(parse_since).transpose()?;
+
+    let filter = LogFilter {
+        author,
+        since: since_dt,
+        grep,
+    };
+
+    let commits = filtered(&ctx.repo, count, &filter)?;
+
+    if commits.is_empty() {
+        if !ctx.json {
+            println!("{}", theme::dim("No commits found."));
+        } else {
+            println!("[]");
+        }
+        return Ok(());
+    }
+
+    // Build ref decoration map
+    let mut ref_map: HashMap<git2::Oid, Vec<String>> = HashMap::new();
+    if let Ok(refs) = ctx.repo.repo.references() {
+        for r in refs.flatten() {
+            if let (Some(name), Some(oid)) = (r.shorthand(), r.target()) {
+                ref_map.entry(oid).or_default().push(name.to_string());
+            }
+        }
+    }
+
+    if ctx.json {
+        let items: Vec<CommitJson> = commits
+            .iter()
+            .map(|c| CommitJson {
+                hash: c.short_id.clone(),
+                author: c.author.clone(),
+                date: c.date.to_rfc3339(),
+                message: c.message.clone(),
+                refs: ref_map.get(&c.full_id).cloned().unwrap_or_default(),
+            })
+            .collect();
+        println!("{}", serde_json::to_string(&items)?);
+    } else {
+        for c in &commits {
+            let refs = ref_map.get(&c.full_id).cloned().unwrap_or_default();
+            let ref_label = if refs.is_empty() {
+                String::new()
+            } else {
+                format!("  {}", theme::info(&format!("[{}]", refs.join(", "))))
+            };
+            println!(
+                "{}  {}  {}  {}{}",
+                theme::info(&c.short_id),
+                theme::dim(&theme::relative_time(c.date)),
+                c.author,
+                c.message,
+                ref_label,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_since(s: &str) -> Result<DateTime<Utc>> {
+    // Shorthand: Nd (days), Nw (weeks), Nm (months)
+    if let Some(rest) = s.strip_suffix('d') {
+        if let Ok(n) = rest.parse::<i64>() {
+            return Ok(Utc::now() - Duration::days(n));
+        }
+    }
+    if let Some(rest) = s.strip_suffix('w') {
+        if let Ok(n) = rest.parse::<i64>() {
+            return Ok(Utc::now() - Duration::weeks(n));
+        }
+    }
+    if let Some(rest) = s.strip_suffix('m') {
+        if let Ok(n) = rest.parse::<i64>() {
+            return Ok(Utc::now() - Duration::days(n * 30));
+        }
+    }
+    // YYYY-MM-DD
+    let naive = NaiveDate::parse_from_str(s, "%Y-%m-%d")
+        .map_err(|_| anyhow::anyhow!("Invalid date format: '{}'. Use YYYY-MM-DD, Nd, Nw, or Nm", s))?;
+    Ok(naive.and_hms_opt(0, 0, 0).unwrap().and_utc())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,15 @@
 pub mod cleanup;
 pub mod completions;
+pub mod generate;
+pub mod init;
+pub mod log;
 pub mod review;
+pub mod stash;
 pub mod status;
 pub mod summary;
+pub mod switch;
+pub mod sync;
+pub mod undo;
 
 use crate::config::Config;
 use crate::git::RepoContext;
@@ -10,4 +17,7 @@ use crate::git::RepoContext;
 pub struct CommandContext {
     pub repo: RepoContext,
     pub config: Config,
+    pub json: bool,
+    #[allow(dead_code)]
+    pub no_color: bool,
 }

--- a/src/commands/stash.rs
+++ b/src/commands/stash.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use dialoguer::{Select, theme::ColorfulTheme};
+use crate::commands::CommandContext;
+use crate::display::theme;
+
+struct StashEntry {
+    index: usize,
+    message: String,
+}
+
+pub fn run(ctx: &mut CommandContext) -> Result<()> {
+    let mut entries: Vec<StashEntry> = Vec::new();
+
+    ctx.repo.repo.stash_foreach(|index, message, _oid| {
+        entries.push(StashEntry {
+            index,
+            message: message.to_string(),
+        });
+        true
+    })?;
+
+    if entries.is_empty() {
+        if !ctx.json {
+            println!("{}", theme::dim("No stashes."));
+        }
+        return Ok(());
+    }
+
+    let labels: Vec<String> = entries
+        .iter()
+        .map(|e| format!("stash@{{{}}}: {}", e.index, e.message))
+        .collect();
+
+    let selected = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select stash")
+        .items(&labels)
+        .default(0)
+        .interact()?;
+
+    let stash_index = entries[selected].index;
+
+    let actions = vec!["Apply", "Pop", "Drop", "Cancel"];
+    let action = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Action")
+        .items(&actions)
+        .default(0)
+        .interact()?;
+
+    match action {
+        0 => {
+            // Apply
+            match ctx.repo.repo.stash_apply(stash_index, None) {
+                Ok(()) => {
+                    if !ctx.json {
+                        println!("{}", theme::success("Stash applied."));
+                    }
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("conflict") || msg.contains("merge") {
+                        println!("{}", theme::warning(&format!("Conflicts when applying stash: {}", msg)));
+                    } else {
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+        1 => {
+            // Pop
+            match ctx.repo.repo.stash_pop(stash_index, None) {
+                Ok(()) => {
+                    if !ctx.json {
+                        println!("{}", theme::success("Stash popped."));
+                    }
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("conflict") || msg.contains("merge") {
+                        println!("{}", theme::warning(&format!("Conflicts when popping stash: {}", msg)));
+                    } else {
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+        2 => {
+            // Drop
+            ctx.repo.repo.stash_drop(stash_index)?;
+            if !ctx.json {
+                println!("{}", theme::success("Stash dropped."));
+            }
+        }
+        _ => {
+            if !ctx.json {
+                println!("{}", theme::dim("Cancelled."));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,10 +1,65 @@
 use anyhow::Result;
+use serde::Serialize;
 use crate::commands::CommandContext;
 use crate::display::{tables, theme};
 use crate::git::{commits, status};
 
+#[derive(Serialize)]
+struct FileJson {
+    path: String,
+    status: String,
+}
+
+#[derive(Serialize)]
+struct UpstreamJson {
+    ahead: usize,
+    behind: usize,
+}
+
+#[derive(Serialize)]
+struct CommitJson {
+    hash: String,
+    author: String,
+    date: String,
+    message: String,
+}
+
+#[derive(Serialize)]
+struct StatusJson {
+    branch: String,
+    upstream: Option<UpstreamJson>,
+    staged: Vec<FileJson>,
+    unstaged: Vec<FileJson>,
+    untracked: Vec<FileJson>,
+    stash_count: usize,
+    recent_commits: Vec<CommitJson>,
+}
+
 pub fn run(ctx: &CommandContext) -> Result<()> {
     let repo_status = status::get_repo_status(&ctx.repo)?;
+    let commits = commits::recent(&ctx.repo, 5)?;
+
+    if ctx.json {
+        let json = StatusJson {
+            branch: repo_status.branch.clone(),
+            upstream: repo_status.upstream.as_ref().map(|u| UpstreamJson {
+                ahead: u.ahead,
+                behind: u.behind,
+            }),
+            staged: repo_status.staged.iter().map(|f| FileJson { path: f.path.clone(), status: f.status.clone() }).collect(),
+            unstaged: repo_status.unstaged.iter().map(|f| FileJson { path: f.path.clone(), status: f.status.clone() }).collect(),
+            untracked: repo_status.untracked.iter().map(|f| FileJson { path: f.path.clone(), status: f.status.clone() }).collect(),
+            stash_count: repo_status.stash_count,
+            recent_commits: commits.iter().map(|c| CommitJson {
+                hash: c.short_id.clone(),
+                author: c.author.clone(),
+                date: c.date.to_rfc3339(),
+                message: c.message.clone(),
+            }).collect(),
+        };
+        println!("{}", serde_json::to_string(&json)?);
+        return Ok(());
+    }
 
     // Branch header
     println!(
@@ -67,7 +122,6 @@ pub fn run(ctx: &CommandContext) -> Result<()> {
     }
 
     // Recent commits
-    let commits = commits::recent(&ctx.repo, 5)?;
     if !commits.is_empty() {
         println!("{}", theme::heading("Recent commits:"));
         println!("{}", tables::commit_table(&commits));

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -1,0 +1,119 @@
+use anyhow::{anyhow, Result};
+use dialoguer::{FuzzySelect, theme::ColorfulTheme};
+use git2::BranchType;
+use serde::Serialize;
+use crate::commands::CommandContext;
+use crate::display::theme;
+
+#[derive(Serialize)]
+struct SwitchJson {
+    branch: String,
+    action: String,
+}
+
+pub fn run(ctx: &CommandContext, include_remote: bool) -> Result<()> {
+    let repo = &ctx.repo.repo;
+
+    let current = repo
+        .head()
+        .ok()
+        .and_then(|h| h.shorthand().map(|s| s.to_string()))
+        .unwrap_or_default();
+
+    let mut branch_names: Vec<String> = Vec::new();
+
+    for branch in repo.branches(Some(BranchType::Local))? {
+        let (branch, _) = branch?;
+        if let Some(name) = branch.name()? {
+            let label = if name == current {
+                format!("* {}", name)
+            } else {
+                name.to_string()
+            };
+            branch_names.push(label);
+        }
+    }
+
+    if include_remote {
+        for branch in repo.branches(Some(BranchType::Remote))? {
+            let (branch, _) = branch?;
+            if let Some(name) = branch.name()? {
+                let local_name = name.strip_prefix("origin/").unwrap_or(name);
+                if local_name != "HEAD" && local_name != current && !branch_names.contains(&local_name.to_string()) {
+                    branch_names.push(local_name.to_string());
+                }
+            }
+        }
+    }
+
+    if branch_names.is_empty() {
+        println!("{}", theme::dim("No branches available."));
+        return Ok(());
+    }
+
+    if !dialoguer::console::Term::stdout().is_term() {
+        return Err(anyhow!("switch requires an interactive terminal"));
+    }
+
+    let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt("Switch to branch")
+        .items(&branch_names)
+        .interact()?;
+
+    let raw = &branch_names[selection];
+    let name = raw.strip_prefix("* ").unwrap_or(raw);
+
+    if name == current {
+        if !ctx.json {
+            println!("{}", theme::dim(&format!("Already on '{}'", name)));
+        }
+        return Ok(());
+    }
+
+    // Try to find existing local branch
+    let checkout_result = if repo.find_branch(name, BranchType::Local).is_ok() {
+        checkout_local(repo, name)
+    } else if include_remote {
+        // Create local tracking branch from remote
+        create_and_checkout(repo, name)
+    } else {
+        checkout_local(repo, name)
+    };
+
+    match checkout_result {
+        Ok(()) => {
+            if ctx.json {
+                println!("{}", serde_json::to_string(&SwitchJson {
+                    branch: name.to_string(),
+                    action: "switched".to_string(),
+                })?);
+            } else {
+                println!("{} {}", theme::success("Switched to"), name);
+            }
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("unstaged") || msg.contains("overwritten") || msg.contains("local changes") {
+                return Err(anyhow!("Cannot switch: uncommitted changes. Commit or stash first."));
+            }
+            return Err(e);
+        }
+    }
+
+    Ok(())
+}
+
+fn checkout_local(repo: &git2::Repository, name: &str) -> Result<()> {
+    let obj = repo.revparse_single(&format!("refs/heads/{}", name))?;
+    repo.checkout_tree(&obj, None)?;
+    repo.set_head(&format!("refs/heads/{}", name))?;
+    Ok(())
+}
+
+fn create_and_checkout(repo: &git2::Repository, name: &str) -> Result<()> {
+    let remote_ref = format!("refs/remotes/origin/{}", name);
+    let obj = repo.revparse_single(&remote_ref)?;
+    let commit = obj.peel_to_commit()?;
+    repo.branch(name, &commit, false)?;
+    checkout_local(repo, name)
+}

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,0 +1,70 @@
+use anyhow::{anyhow, Result};
+use serde::Serialize;
+use std::process::Stdio;
+use crate::commands::CommandContext;
+use crate::config::SyncStrategy;
+use crate::display::theme;
+
+#[derive(Serialize)]
+struct SyncJson {
+    success: bool,
+    strategy: String,
+}
+
+pub fn run(ctx: &CommandContext, base: Option<&str>) -> Result<()> {
+    let base_branch = base
+        .unwrap_or(&ctx.config.base_branch)
+        .to_string();
+
+    if !ctx.json {
+        println!("{}", theme::heading(&format!("Syncing with origin/{}", base_branch)));
+    }
+
+    // Fetch
+    let fetch_status = std::process::Command::new("git")
+        .args(["fetch", "origin"])
+        .stdout(if ctx.json { Stdio::null() } else { Stdio::inherit() })
+        .stderr(if ctx.json { Stdio::null() } else { Stdio::inherit() })
+        .status()?;
+
+    if !fetch_status.success() {
+        return Err(anyhow!("git fetch origin failed. Check your network connection and remote configuration."));
+    }
+
+    let strategy_str = match ctx.config.sync_strategy {
+        SyncStrategy::Rebase => "rebase",
+        SyncStrategy::Merge => "merge",
+    };
+
+    let remote_ref = format!("origin/{}", base_branch);
+    let args: Vec<&str> = match ctx.config.sync_strategy {
+        SyncStrategy::Rebase => vec!["rebase", &remote_ref],
+        SyncStrategy::Merge => vec!["merge", &remote_ref],
+    };
+
+    let sync_status = std::process::Command::new("git")
+        .args(&args)
+        .stdout(if ctx.json { Stdio::null() } else { Stdio::inherit() })
+        .stderr(if ctx.json { Stdio::null() } else { Stdio::inherit() })
+        .status()?;
+
+    if !sync_status.success() {
+        let hint = if matches!(ctx.config.sync_strategy, SyncStrategy::Rebase) {
+            "Resolve conflicts, then run `git rebase --continue` or `git rebase --abort`."
+        } else {
+            "Resolve conflicts, then commit the merge."
+        };
+        return Err(anyhow!("git {} failed. {}", strategy_str, hint));
+    }
+
+    if ctx.json {
+        println!("{}", serde_json::to_string(&SyncJson {
+            success: true,
+            strategy: strategy_str.to_string(),
+        })?);
+    } else {
+        println!("{}", theme::success(&format!("Synced via {} with origin/{}", strategy_str, base_branch)));
+    }
+
+    Ok(())
+}

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -1,0 +1,115 @@
+use anyhow::{anyhow, Result};
+use dialoguer::{Confirm, Select, theme::ColorfulTheme};
+use serde::Serialize;
+use crate::commands::CommandContext;
+use crate::display::theme;
+use crate::git::commits;
+
+#[derive(Serialize)]
+struct UndoJson {
+    reset_mode: String,
+    commits_undone: usize,
+    new_head: String,
+}
+
+pub fn run(ctx: &CommandContext, count: usize) -> Result<()> {
+    let recent = commits::recent(&ctx.repo, count)?;
+
+    if recent.is_empty() {
+        return Err(anyhow!("No commits found in history."));
+    }
+
+    let items: Vec<String> = recent
+        .iter()
+        .enumerate()
+        .map(|(_i, c)| format!("{} {} — {}", c.short_id, c.message.chars().take(60).collect::<String>(), c.author))
+        .collect();
+
+    // Show the table and ask how many to undo
+    println!("{}", theme::heading("Recent commits:"));
+    for item in &items {
+        println!("  {}", item);
+    }
+    println!();
+
+    let undo_labels: Vec<String> = (1..=recent.len())
+        .map(|n| format!("Undo {} commit{}", n, if n == 1 { "" } else { "s" }))
+        .collect();
+
+    let undo_sel = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("How many commits to undo?")
+        .items(&undo_labels)
+        .default(0)
+        .interact()?;
+
+    let n = undo_sel + 1;
+
+    let mode_labels = vec![
+        "Soft  — keep changes staged",
+        "Mixed — keep changes unstaged (default)",
+        "Hard  — discard all working tree changes",
+    ];
+
+    let mode_sel = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Reset mode")
+        .items(&mode_labels)
+        .default(1)
+        .interact()?;
+
+    let reset_mode = match mode_sel {
+        0 => git2::ResetType::Soft,
+        1 => git2::ResetType::Mixed,
+        _ => git2::ResetType::Hard,
+    };
+
+    if mode_sel == 2 {
+        let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Hard reset will discard all working tree changes. Continue?")
+            .default(false)
+            .interact()?;
+        if !confirmed {
+            println!("{}", theme::dim("Aborted."));
+            return Ok(());
+        }
+    }
+
+    // Walk back N parents from HEAD
+    let repo = &ctx.repo.repo;
+    let head = repo.head()?.peel_to_commit()?;
+    let mut target = head.clone();
+    for i in 0..n {
+        let parent_count = target.parent_count();
+        if parent_count == 0 {
+            return Err(anyhow!("Not enough history: only {} commit{} available.", i, if i == 1 { "" } else { "s" }));
+        }
+        target = target.parent(0)?;
+    }
+
+    let target_obj = target.as_object();
+    repo.reset(target_obj, reset_mode, None)?;
+
+    let mode_str = match mode_sel {
+        0 => "soft",
+        1 => "mixed",
+        _ => "hard",
+    };
+
+    if ctx.json {
+        println!("{}", serde_json::to_string(&UndoJson {
+            reset_mode: mode_str.to_string(),
+            commits_undone: n,
+            new_head: target.id().to_string().chars().take(7).collect(),
+        })?);
+    } else {
+        println!(
+            "{} {} commit{} ({} reset). HEAD is now {}",
+            theme::success("Undone:"),
+            n,
+            if n == 1 { "" } else { "s" },
+            mode_str,
+            target.id().to_string().chars().take(7).collect::<String>(),
+        );
+    }
+
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,21 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+#[derive(Serialize, Deserialize, Clone, Default, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum SyncStrategy {
+    #[default]
+    Rebase,
+    Merge,
+}
+
 #[derive(Serialize, Clone)]
 pub struct Config {
     pub base_branch: String,
     pub protected_branches: Vec<String>,
     pub stale_days: u64,
     pub review_secrets_patterns: Vec<String>,
+    pub sync_strategy: SyncStrategy,
 }
 
 impl Default for Config {
@@ -27,6 +36,7 @@ impl Default for Config {
                 r"ghp_[A-Za-z0-9]+".to_string(),
                 r"password\s*=".to_string(),
             ],
+            sync_strategy: SyncStrategy::default(),
         }
     }
 }
@@ -37,6 +47,7 @@ struct FileConfig {
     protected_branches: Option<Vec<String>>,
     stale_days: Option<u64>,
     review_secrets_patterns: Option<Vec<String>>,
+    sync_strategy: Option<SyncStrategy>,
 }
 
 fn global_config_path() -> Option<PathBuf> {
@@ -60,6 +71,9 @@ fn apply(base: &mut Config, file: FileConfig) {
     }
     if let Some(v) = file.review_secrets_patterns {
         base.review_secrets_patterns = v;
+    }
+    if let Some(v) = file.sync_strategy {
+        base.sync_strategy = v;
     }
 }
 

--- a/src/display/theme.rs
+++ b/src/display/theme.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use owo_colors::OwoColorize;
 
 pub fn heading(s: &str) -> String {
@@ -22,4 +23,30 @@ pub fn dim(s: &str) -> String {
 
 pub fn info(s: &str) -> String {
     format!("{}", s.cyan())
+}
+
+pub fn relative_time(dt: DateTime<Utc>) -> String {
+    let now = Utc::now();
+    let secs = (now - dt).num_seconds();
+    if secs < 60 {
+        "just now".to_string()
+    } else if secs < 3600 {
+        let m = secs / 60;
+        format!("{} minute{} ago", m, if m == 1 { "" } else { "s" })
+    } else if secs < 86400 {
+        let h = secs / 3600;
+        format!("{} hour{} ago", h, if h == 1 { "" } else { "s" })
+    } else if secs < 7 * 86400 {
+        let d = secs / 86400;
+        format!("{} day{} ago", d, if d == 1 { "" } else { "s" })
+    } else if secs < 30 * 86400 {
+        let w = secs / (7 * 86400);
+        format!("{} week{} ago", w, if w == 1 { "" } else { "s" })
+    } else if secs < 365 * 86400 {
+        let mo = secs / (30 * 86400);
+        format!("{} month{} ago", mo, if mo == 1 { "" } else { "s" })
+    } else {
+        let y = secs / (365 * 86400);
+        format!("{} year{} ago", y, if y == 1 { "" } else { "s" })
+    }
 }

--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -2,9 +2,53 @@ use chrono::{DateTime, Utc, TimeZone};
 use crate::error::GitPilotError;
 use super::RepoContext;
 
+pub struct LogFilter<'a> {
+    pub author: Option<&'a str>,
+    pub since: Option<DateTime<Utc>>,
+    pub grep: Option<&'a str>,
+}
+
+pub fn filtered(ctx: &RepoContext, count: usize, filter: &LogFilter) -> Result<Vec<CommitSummary>, GitPilotError> {
+    let repo = &ctx.repo;
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push_head()?;
+    revwalk.set_sorting(git2::Sort::TIME)?;
+
+    let mut results = Vec::new();
+    let mut checked = 0usize;
+    for oid in revwalk {
+        if checked >= 10_000 || results.len() >= count {
+            break;
+        }
+        checked += 1;
+        let oid = oid?;
+        let commit = repo.find_commit(oid)?;
+        let summary = commit_to_summary(&commit);
+
+        if let Some(author) = filter.author {
+            if !summary.author.to_lowercase().contains(&author.to_lowercase()) {
+                continue;
+            }
+        }
+        if let Some(since) = filter.since {
+            if summary.date < since {
+                continue;
+            }
+        }
+        if let Some(grep) = filter.grep {
+            if !summary.message.to_lowercase().contains(&grep.to_lowercase()) {
+                continue;
+            }
+        }
+        results.push(summary);
+    }
+    Ok(results)
+}
+
 #[derive(Debug)]
 pub struct CommitSummary {
     pub short_id: String,
+    pub full_id: git2::Oid,
     pub message: String,
     pub author: String,
     pub date: DateTime<Utc>,
@@ -44,19 +88,12 @@ pub fn range(ctx: &RepoContext, base_oid: git2::Oid, head_oid: git2::Oid) -> Res
     Ok(commits)
 }
 
-fn commit_to_summary(commit: &git2::Commit) -> CommitSummary {
-    let short_id = commit
-        .id()
-        .to_string()
-        .chars()
-        .take(7)
-        .collect();
-    let message = commit
-        .summary()
-        .unwrap_or("")
-        .to_string();
+pub fn commit_to_summary(commit: &git2::Commit) -> CommitSummary {
+    let full_id = commit.id();
+    let short_id = full_id.to_string().chars().take(7).collect();
+    let message = commit.summary().unwrap_or("").to_string();
     let author = commit.author().name().unwrap_or("?").to_string();
     let timestamp = commit.time().seconds();
     let date = Utc.timestamp_opt(timestamp, 0).single().unwrap_or_else(Utc::now);
-    CommitSummary { short_id, message, author, date }
+    CommitSummary { short_id, full_id, message, author, date }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,42 +10,132 @@ use clap::Parser;
 use cli::{Cli, Commands};
 use commands::CommandContext;
 use config::Config;
+use display::theme;
 use git::RepoContext;
+use std::thread::JoinHandle;
+
+fn maybe_start_update_checker() -> Option<JoinHandle<Option<String>>> {
+    if std::env::var("GITPILOT_NO_UPDATE_CHECK").is_ok() {
+        return None;
+    }
+    Some(std::thread::spawn(|| {
+        let agent = ureq::AgentBuilder::new()
+            .timeout(std::time::Duration::from_secs(2))
+            .build();
+        let body: serde_json::Value = agent
+            .get("https://crates.io/api/v1/crates/gitpilot")
+            .set("User-Agent", concat!("gitpilot/", env!("CARGO_PKG_VERSION")))
+            .call()
+            .ok()?
+            .into_json()
+            .ok()?;
+        let latest = body["crate"]["newest_version"].as_str()?.to_string();
+        if latest != env!("CARGO_PKG_VERSION") {
+            Some(latest)
+        } else {
+            None
+        }
+    }))
+}
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    if let Commands::Completions { shell } = &cli.command {
-        return commands::completions::run(*shell);
+    if cli.no_color {
+        owo_colors::set_override(false);
     }
+
+    // Early exits — no repo needed
+    match &cli.command {
+        Commands::Completions { shell } => {
+            return commands::completions::run(*shell);
+        }
+        Commands::Generate { target } => {
+            return commands::generate::run(target);
+        }
+        Commands::Init { hook } => {
+            let config = Config::default();
+            return commands::init::run(&config, *hook);
+        }
+        _ => {}
+    }
+
+    let update_handle = maybe_start_update_checker();
 
     let config = Config::load()?;
 
+    let result = run_command(&cli, config);
+
+    // Print update notice if available
+    if let Some(handle) = update_handle {
+        if let Ok(Some(v)) = handle.join() {
+            eprintln!(
+                "{}",
+                theme::dim(&format!(
+                    "Update available: {} → {}. Run `cargo install gitpilot`.",
+                    env!("CARGO_PKG_VERSION"),
+                    v
+                ))
+            );
+        }
+    }
+
+    result
+}
+
+fn run_command(cli: &Cli, config: Config) -> Result<()> {
     match &cli.command {
         Commands::Status => {
             let repo = RepoContext::open()?;
-            let ctx = CommandContext { repo, config };
+            let ctx = CommandContext { repo, config, json: cli.json, no_color: cli.no_color };
             commands::status::run(&ctx)?;
         }
         Commands::Summary { base } => {
             let repo = RepoContext::open()?;
-            let ctx = CommandContext { repo, config };
+            let ctx = CommandContext { repo, config, json: cli.json, no_color: cli.no_color };
             commands::summary::run(&ctx, base.as_deref())?;
         }
         Commands::Review => {
             let repo = RepoContext::open()?;
-            let ctx = CommandContext { repo, config };
+            let ctx = CommandContext { repo, config, json: cli.json, no_color: cli.no_color };
             let exit_code = commands::review::run(&ctx)?;
             if exit_code != 0 {
                 std::process::exit(exit_code);
             }
         }
-        Commands::Cleanup { base } => {
+        Commands::Cleanup { base, dry_run } => {
             let repo = RepoContext::open()?;
-            let ctx = CommandContext { repo, config };
-            commands::cleanup::run(&ctx, base.as_deref())?;
+            let ctx = CommandContext { repo, config, json: cli.json, no_color: cli.no_color };
+            commands::cleanup::run(&ctx, base.as_deref(), *dry_run)?;
         }
-        Commands::Completions { .. } => unreachable!(),
+        Commands::Switch { remote } => {
+            let repo = RepoContext::open()?;
+            let ctx = CommandContext { repo, config, json: cli.json, no_color: cli.no_color };
+            commands::switch::run(&ctx, *remote)?;
+        }
+        Commands::Sync { base } => {
+            let repo = RepoContext::open()?;
+            let ctx = CommandContext { repo, config, json: cli.json, no_color: cli.no_color };
+            commands::sync::run(&ctx, base.as_deref())?;
+        }
+        Commands::Log { author, since, grep, count } => {
+            let repo = RepoContext::open()?;
+            let ctx = CommandContext { repo, config, json: cli.json, no_color: cli.no_color };
+            commands::log::run(&ctx, author.as_deref(), since.as_deref(), grep.as_deref(), *count)?;
+        }
+        Commands::Undo { count } => {
+            let repo = RepoContext::open()?;
+            let ctx = CommandContext { repo, config, json: cli.json, no_color: cli.no_color };
+            commands::undo::run(&ctx, *count)?;
+        }
+        Commands::Stash => {
+            let repo = RepoContext::open()?;
+            let mut ctx = CommandContext { repo, config, json: cli.json, no_color: cli.no_color };
+            commands::stash::run(&mut ctx)?;
+        }
+        Commands::Completions { .. } | Commands::Generate { .. } | Commands::Init { .. } => {
+            unreachable!()
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- Adds 7 new commands: `switch`, `sync`, `log`, `undo`, `stash`, `init`, `generate`
- Adds `--json` global flag with structured output for `status` and `cleanup`
- Adds `--no-color` flag and `NO_COLOR` env var support
- Adds background update checker via crates.io API (disable with `GITPILOT_NO_UPDATE_CHECK=1`)
- Adds `--dry-run` to `cleanup`
- Adds `sync_strategy` config field (`rebase` | `merge`)
- Adds `generate man` for man page generation and moves completions under `generate completions`
- Adds `relative_time()` helper in `display/theme.rs`
- Enables `fuzzy-select` feature for `dialoguer` and `supports-colors` for `owo-colors`

## Test plan

- [x] `gitpilot switch` — fuzzy select local branches
- [x] `gitpilot switch --remote` — includes remote branches
- [x] `gitpilot log` / `gitpilot log --author "Name" --since 7d --grep "feat"`
- [x] `gitpilot undo` — interactive reset
- [x] `gitpilot stash` — interactive stash manager
- [x] `gitpilot sync` / `gitpilot sync --base develop`
- [x] `gitpilot init` / `gitpilot init --hook`
- [x] `gitpilot cleanup --dry-run`
- [x] `gitpilot status --json`
- [x] `gitpilot generate man` / `gitpilot generate completions zsh`
- [x] `NO_COLOR=1 gitpilot status` / `gitpilot --no-color status`
- [x] `GITPILOT_NO_UPDATE_CHECK=1 gitpilot status`
- [x] `cargo build` compiles cleanly